### PR TITLE
add i18n support for Chinese and English

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "tailwind-merge": "^3.4.0",
         "tailwindcss": "^4.1.18",
         "vue": "^3.5.13",
+        "vue-i18n": "^11.2.8",
         "vue-sonner": "^2.0.9"
     },
     "devDependencies": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -15,9 +15,11 @@ import UpdateModal from '@/components/UpdateModal.vue'
 import ImportDialog from '@/components/ImportDialog.vue'
 import { useCopyManager } from '@/composables/useCopyManager'
 import { useUpdateChecker } from '@/composables/useUpdateChecker'
+import { useI18n } from '@/composables/useI18n'
 import { isBackup } from '@/types'
 
 const colorMode = useColorMode()
+const { t } = useI18n()
 const { updateAvailable, updateInfo, dismissed, dismiss } = useUpdateChecker()
 
 const {
@@ -57,11 +59,7 @@ const {
 } = useCopyManager()
 
 function isBackupSource(backup: { id: string }): boolean {
-    return !!(
-        source.value &&
-        isBackup(source.value) &&
-        source.value.id === backup.id
-    )
+    return !!(source.value && isBackup(source.value) && source.value.id === backup.id)
 }
 
 function toggleDarkMode() {
@@ -119,7 +117,7 @@ onMounted(init)
                             class="size-8 animate-spin rounded-full border-2 border-muted border-t-primary"
                         />
                         <p class="text-sm text-muted-foreground">
-                            Scanning EVE installations...
+                            {{ t('common.loading') }}
                         </p>
                     </div>
                 </div>
@@ -131,11 +129,10 @@ onMounted(init)
                         >
                             <Rocket class="size-12 text-muted-foreground" />
                             <h3 class="font-semibold">
-                                No EVE Installations Found
+                                {{ t('empty.noEveInstallations') }}
                             </h3>
                             <p class="text-sm text-muted-foreground">
-                                Make sure EVE Online is installed and has been
-                                launched at least once.
+                                {{ t('empty.noEveInstallationsDesc') }}
                             </p>
                             <Button
                                 variant="outline"
@@ -144,7 +141,7 @@ onMounted(init)
                                 @click="selectCustomEvePath"
                             >
                                 <FolderOpen class="mr-2 size-4" />
-                                Set custom folder path
+                                {{ t('settings.setCustomPath') }}
                             </Button>
                         </div>
                     </div>

--- a/src/components/AccountItem.vue
+++ b/src/components/AccountItem.vue
@@ -30,6 +30,9 @@ import {
     RotateCcw,
 } from 'lucide-vue-next'
 import type { SettingsEntry, SettingsKind, BackupEntry } from '@/types'
+import { useI18n } from '@/composables/useI18n'
+
+const { t } = useI18n()
 
 const props = defineProps<{
     entry: SettingsEntry
@@ -145,7 +148,7 @@ function startEdit() {
                             <ArrowUpFromLine class="size-4" />
                         </Button>
                     </TooltipTrigger>
-                    <TooltipContent side="bottom">Source</TooltipContent>
+                    <TooltipContent side="bottom">{{ t('actions.source') }}</TooltipContent>
                 </Tooltip>
                 <Tooltip>
                     <TooltipTrigger as-child>
@@ -159,7 +162,7 @@ function startEdit() {
                             <ArrowDownToLine class="size-4" />
                         </Button>
                     </TooltipTrigger>
-                    <TooltipContent side="bottom">Target</TooltipContent>
+                    <TooltipContent side="bottom">{{ t('actions.target') }}</TooltipContent>
                 </Tooltip>
                 <DropdownMenu>
                     <DropdownMenuTrigger as-child>
@@ -170,12 +173,12 @@ function startEdit() {
                     <DropdownMenuContent align="end">
                         <DropdownMenuItem @select="emit('backup', entry)">
                             <Save class="mr-2 size-4" />
-                            Create backup
+                            {{ t('actions.createBackup') }}
                         </DropdownMenuItem>
                         <DropdownMenuSub v-if="backups.length">
                             <DropdownMenuSubTrigger>
                                 <RotateCcw class="mr-2 size-4" />
-                                Restore from backup
+                                {{ t('actions.restoreFromBackup') }}
                             </DropdownMenuSubTrigger>
                             <DropdownMenuSubContent>
                                 <DropdownMenuItem
@@ -193,7 +196,7 @@ function startEdit() {
                         </DropdownMenuSub>
                         <DropdownMenuItem v-else disabled>
                             <RotateCcw class="mr-2 size-4" />
-                            No backups available
+                            {{ t('actions.noBackupsAvailable') }}
                         </DropdownMenuItem>
                     </DropdownMenuContent>
                 </DropdownMenu>

--- a/src/components/BackupItem.vue
+++ b/src/components/BackupItem.vue
@@ -19,6 +19,9 @@ import {
     ArrowDownToLine,
 } from 'lucide-vue-next'
 import type { BackupEntry, SettingsEntry } from '@/types'
+import { useI18n } from '@/composables/useI18n'
+
+const { t } = useI18n()
 
 defineProps<{
     backup: BackupEntry
@@ -68,12 +71,12 @@ const emit = defineEmits<{
                         @select="emit('setSource', backup)"
                     >
                         <ArrowUpFromLine class="mr-2 size-4" />
-                        Use as source
+                        {{ t('actions.useAsSource') }}
                     </DropdownMenuItem>
                     <DropdownMenuSub v-if="targets.length">
                         <DropdownMenuSubTrigger>
                             <ArrowDownToLine class="mr-2 size-4" />
-                            Apply to...
+                            {{ t('actions.applyTo') }}
                         </DropdownMenuSubTrigger>
                         <DropdownMenuSubContent
                             class="max-h-64 overflow-y-auto"
@@ -92,7 +95,7 @@ const emit = defineEmits<{
                         @select="emit('delete', backup)"
                     >
                         <Trash2 class="mr-2 size-4" />
-                        Delete
+                        {{ t('actions.delete') }}
                     </DropdownMenuItem>
                 </DropdownMenuContent>
             </DropdownMenu>

--- a/src/components/CopyPanel.vue
+++ b/src/components/CopyPanel.vue
@@ -4,6 +4,7 @@ import { Badge } from '@/components/ui/badge'
 import { User, Rocket, ArrowDown, X, Copy } from 'lucide-vue-next'
 import type { SourceItem, SettingsEntry } from '@/types'
 import { isBackup, getServerShortName, getServerColor } from '@/types'
+import { useI18n } from '@/composables/useI18n'
 
 defineProps<{
     source: SourceItem | null
@@ -18,6 +19,8 @@ const emit = defineEmits<{
     clearTargets: []
     executeCopy: []
 }>()
+
+const { t } = useI18n()
 </script>
 
 <template>
@@ -27,7 +30,7 @@ const emit = defineEmits<{
         <div class="shrink-0">
             <div class="mb-1 flex items-center justify-between">
                 <span class="text-xs font-medium text-muted-foreground"
-                    >Source</span
+                    >{{ t('copyPanel.source') }}</span
                 >
                 <Button
                     v-if="source"
@@ -36,7 +39,7 @@ const emit = defineEmits<{
                     class="h-5 px-1.5 text-xs"
                     @click="emit('clearSource')"
                 >
-                    Clear
+                    {{ t('common.clear') }}
                 </Button>
             </div>
             <div
@@ -68,7 +71,7 @@ const emit = defineEmits<{
                     <span
                         v-if="isBackup(source)"
                         class="text-[10px] text-muted-foreground"
-                        >Backup</span
+                        >{{ t('titleBar.backups') }}</span
                     >
                 </div>
                 <Badge
@@ -87,7 +90,7 @@ const emit = defineEmits<{
                 v-else
                 class="rounded border border-dashed bg-background/50 p-3 text-center text-xs text-muted-foreground"
             >
-                No source selected
+                {{ t('copyPanel.noSourceSelected') }}
             </div>
         </div>
 
@@ -98,7 +101,7 @@ const emit = defineEmits<{
         <div class="flex min-h-0 flex-1 flex-col overflow-hidden">
             <div class="mb-1 flex shrink-0 items-center justify-between">
                 <span class="text-xs font-medium text-muted-foreground">
-                    Targets
+                    {{ t('copyPanel.targets') }}
                     <span v-if="targets.length" class="ml-1 text-foreground"
                         >({{ targets.length }})</span
                     >
@@ -110,7 +113,7 @@ const emit = defineEmits<{
                     class="h-5 px-1.5 text-xs"
                     @click="emit('clearTargets')"
                 >
-                    Clear
+                    {{ t('common.clear') }}
                 </Button>
             </div>
             <div class="flex-1 overflow-y-auto rounded border bg-background">
@@ -169,7 +172,7 @@ const emit = defineEmits<{
                     v-else
                     class="flex h-full min-h-20 items-center justify-center p-3 text-center text-xs text-muted-foreground"
                 >
-                    No targets selected
+                    {{ t('copyPanel.noTargetsSelected') }}
                 </div>
             </div>
         </div>
@@ -180,7 +183,7 @@ const emit = defineEmits<{
             @click="emit('executeCopy')"
         >
             <Copy class="size-4" />
-            {{ copying ? 'Copying...' : 'Copy Settings' }}
+            {{ copying ? t('copyPanel.copying') : t('copyPanel.copySettings') }}
         </Button>
     </aside>
 </template>

--- a/src/components/ImportDialog.vue
+++ b/src/components/ImportDialog.vue
@@ -14,6 +14,9 @@ import { Switch } from '@/components/ui/switch'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { FilePlus, AlertTriangle, CheckCircle } from 'lucide-vue-next'
 import type { ImportAnalysis } from '@/types'
+import { useI18n } from '@/composables/useI18n'
+
+const { t } = useI18n()
 
 const props = defineProps<{
     open: boolean
@@ -101,10 +104,9 @@ function handleConfirm() {
     <AlertDialog :open="open">
         <AlertDialogContent class="max-w-lg">
             <AlertDialogHeader>
-                <AlertDialogTitle>Import Settings</AlertDialogTitle>
+                <AlertDialogTitle>{{ t('importDialog.title') }}</AlertDialogTitle>
                 <AlertDialogDescription>
-                    Found {{ analysis.total_files }} file(s) in the archive.
-                    Review and select which conflicts to overwrite.
+                    {{ t('importDialog.foundFiles', { count: analysis.total_files }) }}
                 </AlertDialogDescription>
             </AlertDialogHeader>
 
@@ -114,7 +116,7 @@ function handleConfirm() {
                     <div v-if="analysis.new_files.length > 0">
                         <div class="mb-1.5 flex items-center gap-2">
                             <FilePlus class="size-4 text-green-500" />
-                            <span class="text-sm font-medium">New files</span>
+                            <span class="text-sm font-medium">{{ t('importDialog.newFiles') }}</span>
                             <Badge variant="secondary">{{
                                 analysis.new_files.length
                             }}</Badge>
@@ -144,7 +146,7 @@ function handleConfirm() {
                     <div v-if="analysis.conflicts.length > 0">
                         <div class="mb-1.5 flex items-center gap-2">
                             <AlertTriangle class="size-4 text-yellow-500" />
-                            <span class="text-sm font-medium">Conflicts</span>
+                            <span class="text-sm font-medium">{{ t('importDialog.conflicts') }}</span>
                             <Badge variant="destructive">{{
                                 analysis.conflicts.length
                             }}</Badge>
@@ -153,7 +155,7 @@ function handleConfirm() {
                                 @click="toggleAll(!allSelected)"
                             >
                                 {{
-                                    allSelected ? 'Deselect all' : 'Select all'
+                                    allSelected ? t('importDialog.deselectAll') : t('importDialog.selectAll')
                                 }}
                             </button>
                         </div>
@@ -190,7 +192,7 @@ function handleConfirm() {
                     <div v-if="analysis.unchanged.length > 0">
                         <div class="mb-1.5 flex items-center gap-2">
                             <CheckCircle class="size-4 text-muted-foreground" />
-                            <span class="text-sm font-medium">Unchanged</span>
+                            <span class="text-sm font-medium">{{ t('importDialog.unchanged') }}</span>
                             <Badge variant="outline">{{
                                 analysis.unchanged.length
                             }}</Badge>
@@ -220,17 +222,17 @@ function handleConfirm() {
 
             <AlertDialogFooter>
                 <Button variant="outline" @click="emit('cancel')">
-                    Cancel
+                    {{ t('common.cancel') }}
                 </Button>
                 <Button @click="handleConfirm">
-                    Import
+                    {{ t('importExport.import') }}
                     <template
                         v-if="
                             analysis.conflicts.length > 0 &&
                             selectedConflicts.size > 0
                         "
                     >
-                        ({{ selectedConflicts.size }} overwrite)
+                        ({{ selectedConflicts.size }} {{ t('importDialog.overwrite') }})
                     </template>
                 </Button>
             </AlertDialogFooter>

--- a/src/components/ProfileCard.vue
+++ b/src/components/ProfileCard.vue
@@ -17,6 +17,9 @@ import type {
     SettingsKind,
     BackupEntry,
 } from '@/types'
+import { useI18n } from '@/composables/useI18n'
+
+const { t } = useI18n()
 
 const props = defineProps<{
     profile: ProfileData
@@ -117,7 +120,7 @@ const sortedCharacters = computed(() =>
     <div class="space-y-6 text-sm">
         <div v-if="profile.accounts.length">
             <div class="mb-3 flex items-center gap-2">
-                <span class="text-lg font-semibold">Accounts</span>
+                <span class="text-lg font-semibold">{{ t('list.accounts') }}</span>
                 <span v-if="showProfileName" class="text-muted-foreground"
                     >· {{ profile.name }}</span
                 >
@@ -137,7 +140,7 @@ const sortedCharacters = computed(() =>
                                 @click="toggleAccountSort('name')"
                             >
                                 <div class="flex items-center gap-1">
-                                    Name
+                                    {{ t('table.name') }}
                                     <ChevronUp
                                         v-if="
                                             accountSortCol === 'name' &&
@@ -159,7 +162,7 @@ const sortedCharacters = computed(() =>
                                 @click="toggleAccountSort('modified')"
                             >
                                 <div class="flex items-center gap-1">
-                                    Modified
+                                    {{ t('table.modified') }}
                                     <ChevronUp
                                         v-if="
                                             accountSortCol === 'modified' &&
@@ -190,7 +193,7 @@ const sortedCharacters = computed(() =>
                                         )
                                     "
                                 >
-                                    Add all
+                                    {{ t('table.addAll') }}
                                 </Button>
                             </TableHead>
                         </TableRow>
@@ -220,7 +223,7 @@ const sortedCharacters = computed(() =>
 
         <div v-if="profile.characters.length">
             <div class="mb-3 mt-8 flex items-center gap-2">
-                <span class="text-lg font-semibold">Characters</span>
+                <span class="text-lg font-semibold">{{ t('list.characters') }}</span>
                 <span v-if="showProfileName" class="text-muted-foreground"
                     >· {{ profile.name }}</span
                 >
@@ -240,7 +243,7 @@ const sortedCharacters = computed(() =>
                                 @click="toggleCharSort('name')"
                             >
                                 <div class="flex items-center gap-1">
-                                    Name
+                                    {{ t('table.name') }}
                                     <ChevronUp
                                         v-if="
                                             charSortCol === 'name' &&
@@ -262,7 +265,7 @@ const sortedCharacters = computed(() =>
                                 @click="toggleCharSort('modified')"
                             >
                                 <div class="flex items-center gap-1">
-                                    Modified
+                                    {{ t('table.modified') }}
                                     <ChevronUp
                                         v-if="
                                             charSortCol === 'modified' &&
@@ -293,7 +296,7 @@ const sortedCharacters = computed(() =>
                                         )
                                     "
                                 >
-                                    Add all
+                                    {{ t('table.addAll') }}
                                 </Button>
                             </TableHead>
                         </TableRow>

--- a/src/components/ServerSection.vue
+++ b/src/components/ServerSection.vue
@@ -8,6 +8,9 @@ import type {
     SettingsKind,
     BackupEntry,
 } from '@/types'
+import { useI18n } from '@/composables/useI18n'
+
+const { t } = useI18n()
 
 const props = defineProps<{
     server: ServerData
@@ -49,18 +52,16 @@ const emit = defineEmits<{
         <!-- Extra Settings -->
         <div class="mt-8">
             <div class="mb-3">
-                <span class="text-lg font-semibold">Extra</span>
+                <span class="text-lg font-semibold">{{ t('extra.title') }}</span>
             </div>
             <div class="rounded-md border p-4">
                 <div class="flex items-center justify-between gap-4">
                     <div class="flex flex-col gap-1">
                         <span class="text-sm font-medium"
-                            >Always Show Bracket Text</span
+                            >{{ t('extra.alwaysShowBracketText') }}</span
                         >
                         <span class="text-xs text-muted-foreground">
-                            Show ship labels on all brackets in space, not just
-                            selected targets. May impact performance with 200+
-                            pilots on grid. Requires client restart.
+                            {{ t('extra.alwaysShowBracketTextDesc') }}
                         </span>
                     </div>
                     <Switch

--- a/src/components/SettingsBrowser.vue
+++ b/src/components/SettingsBrowser.vue
@@ -19,6 +19,7 @@ import type {
     BackupEntry,
 } from '@/types'
 import { getServerColor } from '@/types'
+import { useI18n } from '@/composables/useI18n'
 
 const props = defineProps<{
     appData: AppData
@@ -41,6 +42,7 @@ const emit = defineEmits<{
     setBracketsAlwaysShow: [serverPath: string, enabled: boolean]
 }>()
 
+const { t } = useI18n()
 const activeTab = ref(props.appData.servers[0]?.info.id || '')
 
 watch(
@@ -87,8 +89,7 @@ function getTargetsForBackup(backup: BackupEntry): SettingsEntry[] {
     const entries: SettingsEntry[] = []
     for (const server of props.appData.servers) {
         for (const profile of server.profiles) {
-            const items =
-                backup.kind === 'char' ? profile.characters : profile.accounts
+            const items = backup.kind === 'char' ? profile.characters : profile.accounts
             entries.push(...items)
         }
     }
@@ -123,7 +124,7 @@ function getTargetsForBackup(backup: BackupEntry): SettingsEntry[] {
                         class="gap-1.5 data-[state=active]:bg-muted"
                     >
                         <Archive class="size-3" />
-                        <span>Backups</span>
+                        <span>{{ t('titleBar.backups') }}</span>
                         <span class="text-xs text-muted-foreground"
                             >({{ appData.backups.length }})</span
                         >
@@ -163,7 +164,7 @@ function getTargetsForBackup(backup: BackupEntry): SettingsEntry[] {
 
                 <TabsContent value="backups" class="mt-0">
                     <div class="mb-3 flex items-center gap-2">
-                        <span class="text-lg font-semibold">Backups</span>
+                        <span class="text-lg font-semibold">{{ t('titleBar.backups') }}</span>
                         <span
                             class="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground"
                         >
@@ -180,7 +181,7 @@ function getTargetsForBackup(backup: BackupEntry): SettingsEntry[] {
                                         @click="toggleBackupSort('name')"
                                     >
                                         <div class="flex items-center gap-1">
-                                            Name
+                                            {{ t('backup.name') }}
                                             <ChevronUp
                                                 v-if="
                                                     backupSortCol === 'name' &&
@@ -202,7 +203,7 @@ function getTargetsForBackup(backup: BackupEntry): SettingsEntry[] {
                                         @click="toggleBackupSort('time')"
                                     >
                                         <div class="flex items-center gap-1">
-                                            Time
+                                            {{ t('backup.date') }}
                                             <ChevronUp
                                                 v-if="
                                                     backupSortCol === 'time' &&

--- a/src/components/SettingsItem.vue
+++ b/src/components/SettingsItem.vue
@@ -31,6 +31,9 @@ import {
     RotateCcw,
 } from 'lucide-vue-next'
 import type { SettingsEntry, SettingsKind, BackupEntry } from '@/types'
+import { useI18n } from '@/composables/useI18n'
+
+const { t } = useI18n()
 
 const props = defineProps<{
     entry: SettingsEntry
@@ -172,7 +175,7 @@ function startEdit() {
                             <ArrowUpFromLine class="size-4" />
                         </Button>
                     </TooltipTrigger>
-                    <TooltipContent side="bottom">Source</TooltipContent>
+                    <TooltipContent side="bottom">{{ t('actions.source') }}</TooltipContent>
                 </Tooltip>
                 <Tooltip>
                     <TooltipTrigger as-child>
@@ -186,7 +189,7 @@ function startEdit() {
                             <ArrowDownToLine class="size-4" />
                         </Button>
                     </TooltipTrigger>
-                    <TooltipContent side="bottom">Target</TooltipContent>
+                    <TooltipContent side="bottom">{{ t('actions.target') }}</TooltipContent>
                 </Tooltip>
                 <DropdownMenu>
                     <DropdownMenuTrigger as-child>
@@ -197,12 +200,12 @@ function startEdit() {
                     <DropdownMenuContent align="end">
                         <DropdownMenuItem @select="emit('backup', entry)">
                             <Save class="mr-2 size-4" />
-                            Create backup
+                            {{ t('actions.createBackup') }}
                         </DropdownMenuItem>
                         <DropdownMenuSub v-if="backups.length">
                             <DropdownMenuSubTrigger>
                                 <RotateCcw class="mr-2 size-4" />
-                                Restore from backup
+                                {{ t('actions.restoreFromBackup') }}
                             </DropdownMenuSubTrigger>
                             <DropdownMenuSubContent>
                                 <DropdownMenuItem
@@ -220,7 +223,7 @@ function startEdit() {
                         </DropdownMenuSub>
                         <DropdownMenuItem v-else disabled>
                             <RotateCcw class="mr-2 size-4" />
-                            No backups available
+                            {{ t('actions.noBackupsAvailable') }}
                         </DropdownMenuItem>
                     </DropdownMenuContent>
                 </DropdownMenu>

--- a/src/components/TitleBar.vue
+++ b/src/components/TitleBar.vue
@@ -16,6 +16,7 @@ import {
     RotateCcw,
     Download,
     Upload,
+    Languages
 } from 'lucide-vue-next'
 import { Button } from '@/components/ui/button'
 import {
@@ -31,6 +32,7 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { useI18n } from '@/composables/useI18n'
 
 defineProps<{
     loading: boolean
@@ -47,6 +49,7 @@ const emit = defineEmits<{
     importSettings: []
 }>()
 
+const { t, locale, languages, changeLanguage } = useI18n()
 const appWindow = getCurrentWindow()
 const isMac = ref(true)
 const isMaximized = ref(false)
@@ -103,20 +106,16 @@ async function close() {
                         variant="ghost"
                         size="icon"
                         class="size-8"
-                        title="Settings"
+                        :title="t('titleBar.settings')"
                     >
                         <Settings class="size-4" />
                     </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" class="w-64">
-                    <DropdownMenuLabel>EVE Settings Folder</DropdownMenuLabel>
+                    <DropdownMenuLabel>{{ t('settings.eveSettingsFolder') }}</DropdownMenuLabel>
                     <DropdownMenuItem @click="emit('selectEvePath')">
                         <FolderOpen class="mr-2 size-4" />
-                        {{
-                            customEvePath
-                                ? 'Change folder...'
-                                : 'Set custom folder...'
-                        }}
+                        {{ customEvePath ? t('settings.changeFolder') : t('settings.setCustomPath') }}
                     </DropdownMenuItem>
                     <template v-if="customEvePath">
                         <DropdownMenuSeparator />
@@ -127,18 +126,30 @@ async function close() {
                         </DropdownMenuLabel>
                         <DropdownMenuItem @click="emit('clearEvePath')">
                             <RotateCcw class="mr-2 size-4" />
-                            Reset to default
+                            {{ t('settings.resetToDefault') }}
                         </DropdownMenuItem>
                     </template>
                     <DropdownMenuSeparator />
-                    <DropdownMenuLabel>Import / Export</DropdownMenuLabel>
+                    <DropdownMenuLabel>{{ t('importExport.import') }} / {{ t('importExport.export') }}</DropdownMenuLabel>
                     <DropdownMenuItem @click="emit('exportSettings')">
                         <Download class="mr-2 size-4" />
-                        Export settings...
+                        {{ t('importExport.exportSettings') }}
                     </DropdownMenuItem>
                     <DropdownMenuItem @click="emit('importSettings')">
                         <Upload class="mr-2 size-4" />
-                        Import settings...
+                        {{ t('importExport.importSettings') }}
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuLabel>{{ t('settings.language') }}</DropdownMenuLabel>
+                    <DropdownMenuItem 
+                        v-for="lang in languages" 
+                        :key="lang.code"
+                        @click="changeLanguage(lang.code)"
+                        :class="{ 'bg-muted': locale === lang.code }"
+                    >
+                        <Languages class="mr-2 size-4" />
+                        {{ lang.name }}
+                        <span v-if="locale === lang.code" class="ml-auto">✓</span>
                     </DropdownMenuItem>
                 </DropdownMenuContent>
             </DropdownMenu>
@@ -155,7 +166,7 @@ async function close() {
                         <Moon v-else class="size-4" />
                     </Button>
                 </TooltipTrigger>
-                <TooltipContent>Toggle theme</TooltipContent>
+                <TooltipContent>{{ t('titleBar.toggleTheme') }}</TooltipContent>
             </Tooltip>
 
             <Tooltip>
@@ -173,7 +184,7 @@ async function close() {
                         />
                     </Button>
                 </TooltipTrigger>
-                <TooltipContent>Refresh</TooltipContent>
+                <TooltipContent>{{ t('common.refresh') }}</TooltipContent>
             </Tooltip>
 
             <!-- Window controls (Windows/Linux only) -->
@@ -200,7 +211,7 @@ async function close() {
                     </button>
                     <button
                         class="flex size-8 items-center justify-center text-muted-foreground transition-colors hover:bg-destructive hover:text-white"
-                        title="Close"
+                        :title="t('common.close')"
                         @click="close"
                     >
                         <X class="size-4" :stroke-width="1.5" />

--- a/src/components/UpdateModal.vue
+++ b/src/components/UpdateModal.vue
@@ -3,6 +3,9 @@ import { Download, X, ExternalLink } from 'lucide-vue-next'
 import { openUrl } from '@tauri-apps/plugin-opener'
 import { Button } from '@/components/ui/button'
 import type { UpdateInfo } from '@/composables/useUpdateChecker'
+import { useI18n } from '@/composables/useI18n'
+
+const { t } = useI18n()
 
 const props = defineProps<{
     info: UpdateInfo
@@ -33,7 +36,7 @@ function openRelease() {
                         <Download class="size-5 text-primary" />
                     </div>
                     <div>
-                        <h2 class="font-semibold">Update Available</h2>
+                        <h2 class="font-semibold">{{ t('update.updateAvailable') }}</h2>
                         <p class="text-xs text-muted-foreground">
                             v{{ info.current_version }} → v{{
                                 info.latest_version
@@ -53,8 +56,7 @@ function openRelease() {
 
             <div class="p-4">
                 <p class="mb-4 text-sm text-muted-foreground">
-                    A new version of EVE Wrench is available. Update to get the
-                    latest features and bug fixes.
+                    {{ t('update.newVersionAvailable') }}
                 </p>
 
                 <div
@@ -76,11 +78,11 @@ function openRelease() {
                     class="flex-1"
                     @click="emit('dismiss')"
                 >
-                    Later
+                    {{ t('update.later') }}
                 </Button>
                 <Button class="flex-1 gap-2" @click="openRelease">
                     <Download class="size-4" />
-                    Download
+                    {{ t('update.download') }}
                     <ExternalLink class="size-3 opacity-70" />
                 </Button>
             </div>

--- a/src/composables/useConfirm.ts
+++ b/src/composables/useConfirm.ts
@@ -1,4 +1,5 @@
 import { ref } from 'vue'
+import { useI18n } from './useI18n'
 
 interface ConfirmOptions {
     title?: string
@@ -13,15 +14,17 @@ const options = ref<ConfirmOptions>({ description: '' })
 let resolvePromise: ((value: boolean) => void) | null = null
 
 export function useConfirm() {
+    const { t } = useI18n()
+
     function confirm(opts: ConfirmOptions | string): Promise<boolean> {
         if (typeof opts === 'string') {
             opts = { description: opts }
         }
         options.value = {
-            title: opts.title || 'Confirm',
+            title: opts.title || t('dialog.confirm'),
             description: opts.description,
-            confirmText: opts.confirmText || 'Continue',
-            cancelText: opts.cancelText || 'Cancel',
+            confirmText: opts.confirmText || t('dialog.continue'),
+            cancelText: opts.cancelText || t('dialog.cancel'),
             destructive: opts.destructive || false,
         }
         isOpen.value = true

--- a/src/composables/useI18n.ts
+++ b/src/composables/useI18n.ts
@@ -1,0 +1,35 @@
+import { useI18n as useVueI18n } from 'vue-i18n'
+import { supportedLocales } from '../locales'
+import { ref, watch } from 'vue'
+
+/**
+ * 国际化管理组合式函数
+ * 提供语言切换和当前语言信息
+ */
+export function useI18n() {
+  const { locale, t } = useVueI18n()
+  
+  // 当前选择的语言
+  const currentLocale = ref(locale.value)
+  
+  // 支持的语言列表
+  const languages = supportedLocales
+  
+  // 切换语言
+  const changeLanguage = (lang: string) => {
+    currentLocale.value = lang
+    locale.value = lang
+  }
+  
+  // 监听语言变化
+  watch(locale, (newLocale) => {
+    currentLocale.value = newLocale
+  })
+  
+  return {
+    locale: currentLocale,
+    languages,
+    t,
+    changeLanguage
+  }
+}

--- a/src/composables/usePrompt.ts
+++ b/src/composables/usePrompt.ts
@@ -1,4 +1,5 @@
 import { ref } from 'vue'
+import { useI18n } from './useI18n'
 
 interface PromptOptions {
     title?: string
@@ -15,14 +16,16 @@ const inputValue = ref('')
 let resolvePromise: ((value: string | null) => void) | null = null
 
 export function usePrompt() {
+    const { t } = useI18n()
+
     function prompt(opts: PromptOptions): Promise<string | null> {
         options.value = {
-            title: opts.title || 'Input',
+            title: opts.title || t('dialog.input'),
             description: opts.description,
             placeholder: opts.placeholder,
             defaultValue: opts.defaultValue || '',
-            confirmText: opts.confirmText || 'OK',
-            cancelText: opts.cancelText || 'Cancel',
+            confirmText: opts.confirmText || t('dialog.ok'),
+            cancelText: opts.cancelText || t('dialog.cancel'),
         }
         inputValue.value = opts.defaultValue || ''
         isOpen.value = true

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1,0 +1,168 @@
+export default {
+  // Common
+  common: {
+    close: 'Close',
+    loading: 'Loading...',
+    refresh: 'Refresh',
+    clear: 'Clear',
+    cancel: 'Cancel',
+    enabled: 'enabled',
+    disabled: 'disabled'
+  },
+  // Dialog
+  dialog: {
+    confirm: 'Confirm',
+    continue: 'Continue',
+    cancel: 'Cancel',
+    input: 'Input',
+    ok: 'OK',
+    selectEveFolder: 'Select EVE Settings Folder',
+    copySettings: 'Copy Settings',
+    copySettingsDesc: 'Copy settings from "{source}" to {count} target(s)?',
+    copy: 'Copy',
+    createBackup: 'Create Backup',
+    createBackupDesc: 'Enter a name for this backup of {name}',
+    backupName: 'Backup name',
+    create: 'Create',
+    deleteBackup: 'Delete Backup',
+    deleteBackupDesc: 'Are you sure you want to delete "{name}"?',
+    delete: 'Delete',
+    restoreBackup: 'Restore Backup',
+    restoreBackupDesc: 'Restore "{backup}" to {target}? This will overwrite current settings.',
+    restore: 'Restore',
+    applyBackup: 'Apply Backup',
+    applyBackupDesc: 'Apply "{backup}" to {target}? This will overwrite current settings.',
+    apply: 'Apply',
+    exportSettings: 'Export EVE Settings',
+    importSettings: 'Import EVE Settings'
+  },
+  // Toast messages
+  toast: {
+    dataRefreshed: 'Data refreshed',
+    dataRefreshedDesc: 'Found {servers} server(s) and {backups} backup(s)',
+    loadDataFailed: 'Failed to load data',
+    customPathSet: 'Custom path set',
+    setPathFailed: 'Failed to set path',
+    pathReset: 'Path reset',
+    pathResetDesc: 'Using default EVE settings location',
+    resetPathFailed: 'Failed to reset path',
+    noSourceSelected: 'No source selected',
+    noSourceSelectedDesc: 'Select a source first before adding targets',
+    typeMismatch: 'Type mismatch',
+    typeMismatchDesc: 'Target must be the same type as source',
+    invalidTarget: 'Invalid target',
+    invalidTargetDesc: 'Cannot use the same file as source and target',
+    settingsCopied: 'Settings copied',
+    settingsCopiedDesc: 'Successfully copied to {count} target(s)',
+    copyFailed: 'Copy failed',
+    backupCreated: 'Backup created',
+    backupCreatedDesc: '"{name}" has been saved',
+    backupFailed: 'Backup failed',
+    backupDeleted: 'Backup deleted',
+    backupDeletedDesc: '"{name}" has been removed',
+    deleteFailed: 'Delete failed',
+    backupRestored: 'Backup restored',
+    backupRestoredDesc: '"{name}" has been applied',
+    restoreFailed: 'Restore failed',
+    backupApplied: 'Backup applied',
+    backupAppliedDesc: '"{backup}" has been applied to {target}',
+    applyFailed: 'Apply failed',
+    settingsExported: 'Settings exported',
+    settingsExportedDesc: 'Exported {count} file(s) to {path}',
+    exportFailed: 'Export failed',
+    importAnalysisFailed: 'Import analysis failed',
+    settingsImported: 'Settings imported',
+    settingsImportedDesc: 'Imported {imported} file(s), skipped {skipped}, backed up {backedUp}',
+    importFailed: 'Import failed',
+    settingUpdated: 'Setting updated',
+    settingUpdatedDesc: 'Brackets always show {status}',
+    updateSettingFailed: 'Failed to update setting'
+  },
+  // Title Bar
+  titleBar: {
+    settings: 'Settings',
+    backups: 'Backups',
+    toggleTheme: 'Toggle theme'
+  },
+  // Backup related
+  backup: {
+    name: 'Name',
+    date: 'Date'
+  },
+  // Settings related
+  settings: {
+    language: 'Language',
+    setCustomPath: 'Set custom folder path',
+    eveSettingsFolder: 'EVE Settings Folder',
+    changeFolder: 'Change folder...',
+    resetToDefault: 'Reset to default'
+  },
+  // Import/Export
+  importExport: {
+    import: 'Import',
+    export: 'Export',
+    importSettings: 'Import settings...',
+    exportSettings: 'Export settings...',
+  },
+  // Update related
+  update: {
+    available: 'Update Available',
+    download: 'Download',
+    updateAvailable: 'Update Available',
+    newVersionAvailable: 'A new version of EVE Wrench is available. Update to get the latest features and bug fixes.',
+    later: 'Later'
+  },
+  // Copy Panel
+  copyPanel: {
+    source: 'Source',
+    targets: 'Targets',
+    noSourceSelected: 'No source selected',
+    noTargetsSelected: 'No targets selected',
+    copying: 'Copying...',
+    copySettings: 'Copy Settings'
+  },
+  // Table related
+  table: {
+    name: 'Name',
+    modified: 'Modified',
+    addAll: 'Add all'
+  },
+  // Account/Character list
+  list: {
+    accounts: 'Accounts',
+    characters: 'Characters'
+  },
+  // Actions
+  actions: {
+    source: 'Source',
+    target: 'Target',
+    createBackup: 'Create backup',
+    restoreFromBackup: 'Restore from backup',
+    noBackupsAvailable: 'No backups available',
+    useAsSource: 'Use as source',
+    applyTo: 'Apply to...',
+    delete: 'Delete'
+  },
+  // Import Dialog
+  importDialog: {
+    title: 'Import Settings',
+    foundFiles: 'Found {count} file(s) in the archive. Review and select which conflicts to overwrite.',
+    newFiles: 'New files',
+    conflicts: 'Conflicts',
+    unchanged: 'Unchanged',
+    selectAll: 'Select all',
+    deselectAll: 'Deselect all',
+    overwrite: 'overwrite'
+  },
+  // Extra settings
+  extra: {
+    title: 'Extra',
+    alwaysShowBracketText: 'Always Show Bracket Text',
+    alwaysShowBracketTextDesc: 'Show ship labels on all brackets in space, not just selected targets. May impact performance with 200+ pilots on grid. Requires client restart.'
+  },
+  // Empty state
+  empty: {
+    noEveInstallations: 'No EVE Installations Found',
+    noEveInstallationsDesc: 'Make sure EVE Online is installed and has been launched at least once.'
+  }
+}

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -1,0 +1,22 @@
+import { createI18n } from 'vue-i18n'
+import en from './en'
+import zh from './zh'
+
+// 支持的语言列表
+export const supportedLocales = [
+  { code: 'en', name: 'English' },
+  { code: 'zh', name: '中文' }
+]
+
+// 创建i18n实例
+const i18n = createI18n({
+  legacy: false, // 使用组合式API
+  locale: 'en', // 默认语言
+  fallbackLocale: 'en', // 回退语言
+  messages: {
+    en,
+    zh
+  }
+})
+
+export default i18n

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -1,0 +1,168 @@
+export default {
+  // 通用
+  common: {
+    close: '关闭',
+    loading: '加载中...',
+    refresh: '刷新',
+    clear: '清除',
+    cancel: '取消',
+    enabled: '已启用',
+    disabled: '已禁用'
+  },
+  // 对话框
+  dialog: {
+    confirm: '确认',
+    continue: '继续',
+    cancel: '取消',
+    input: '输入',
+    ok: '确定',
+    selectEveFolder: '选择EVE设置文件夹',
+    copySettings: '复制设置',
+    copySettingsDesc: '将设置从"{source}"复制到 {count} 个目标？',
+    copy: '复制',
+    createBackup: '创建备份',
+    createBackupDesc: '为 {name} 输入备份名称',
+    backupName: '备份名称',
+    create: '创建',
+    deleteBackup: '删除备份',
+    deleteBackupDesc: '确定要删除"{name}"吗？',
+    delete: '删除',
+    restoreBackup: '恢复备份',
+    restoreBackupDesc: '将"{backup}"恢复到 {target}？这将覆盖当前设置。',
+    restore: '恢复',
+    applyBackup: '应用备份',
+    applyBackupDesc: '将"{backup}"应用到 {target}？这将覆盖当前设置。',
+    apply: '应用',
+    exportSettings: '导出EVE设置',
+    importSettings: '导入EVE设置'
+  },
+  // 提示消息
+  toast: {
+    dataRefreshed: '数据已刷新',
+    dataRefreshedDesc: '找到 {servers} 个服务器和 {backups} 个备份',
+    loadDataFailed: '加载数据失败',
+    customPathSet: '自定义路径已设置',
+    setPathFailed: '设置路径失败',
+    pathReset: '路径已重置',
+    pathResetDesc: '使用默认EVE设置位置',
+    resetPathFailed: '重置路径失败',
+    noSourceSelected: '未选择源',
+    noSourceSelectedDesc: '请先选择源再添加目标',
+    typeMismatch: '类型不匹配',
+    typeMismatchDesc: '目标必须与源类型相同',
+    invalidTarget: '无效目标',
+    invalidTargetDesc: '不能将同一文件同时作为源和目标',
+    settingsCopied: '设置已复制',
+    settingsCopiedDesc: '成功复制到 {count} 个目标',
+    copyFailed: '复制失败',
+    backupCreated: '备份已创建',
+    backupCreatedDesc: '"{name}" 已保存',
+    backupFailed: '备份失败',
+    backupDeleted: '备份已删除',
+    backupDeletedDesc: '"{name}" 已移除',
+    deleteFailed: '删除失败',
+    backupRestored: '备份已恢复',
+    backupRestoredDesc: '"{name}" 已应用',
+    restoreFailed: '恢复失败',
+    backupApplied: '备份已应用',
+    backupAppliedDesc: '"{backup}" 已应用到 {target}',
+    applyFailed: '应用失败',
+    settingsExported: '设置已导出',
+    settingsExportedDesc: '已导出 {count} 个文件到 {path}',
+    exportFailed: '导出失败',
+    importAnalysisFailed: '导入分析失败',
+    settingsImported: '设置已导入',
+    settingsImportedDesc: '已导入 {imported} 个文件，跳过 {skipped} 个，备份 {backedUp} 个',
+    importFailed: '导入失败',
+    settingUpdated: '设置已更新',
+    settingUpdatedDesc: '始终显示标签 {status}',
+    updateSettingFailed: '更新设置失败'
+  },
+  // 标题栏
+  titleBar: {
+    settings: '设置',
+    backups: '备份',
+    toggleTheme: '切换主题'
+  },
+  // 备份相关
+  backup: {
+    name: '名称',
+    date: '日期'
+  },
+  // 设置相关
+  settings: {
+    language: '语言',
+    setCustomPath: '设置自定义文件夹路径',
+    eveSettingsFolder: 'EVE设置文件夹',
+    changeFolder: '更改文件夹...',
+    resetToDefault: '重置为默认'
+  },
+  // 导入/导出
+  importExport: {
+    import: '导入',
+    export: '导出',
+    importSettings: '导入设置...',
+    exportSettings: '导出设置...',
+  },
+  // 更新相关
+  update: {
+    available: '有可用更新',
+    download: '下载',
+    updateAvailable: '有可用更新',
+    newVersionAvailable: 'EVE Wrench 有新版本可用。更新以获取最新功能和错误修复。',
+    later: '稍后'
+  },
+  // 复制面板
+  copyPanel: {
+    source: '源',
+    targets: '目标',
+    noSourceSelected: '未选择源',
+    noTargetsSelected: '未选择目标',
+    copying: '复制中...',
+    copySettings: '复制设置'
+  },
+  // 表格相关
+  table: {
+    name: '名称',
+    modified: '修改时间',
+    addAll: '全部添加'
+  },
+  // 账户/角色列表
+  list: {
+    accounts: '账户',
+    characters: '角色'
+  },
+  // 操作相关
+  actions: {
+    source: '源',
+    target: '目标',
+    createBackup: '创建备份',
+    restoreFromBackup: '从备份恢复',
+    noBackupsAvailable: '无可用备份',
+    useAsSource: '用作源',
+    applyTo: '应用到...',
+    delete: '删除'
+  },
+  // 导入对话框
+  importDialog: {
+    title: '导入设置',
+    foundFiles: '在归档中找到 {count} 个文件。查看并选择要覆盖的冲突项。',
+    newFiles: '新文件',
+    conflicts: '冲突',
+    unchanged: '未更改',
+    selectAll: '全选',
+    deselectAll: '取消全选',
+    overwrite: '覆盖'
+  },
+  // 额外设置
+  extra: {
+    title: '额外',
+    alwaysShowBracketText: '始终显示标签文本',
+    alwaysShowBracketTextDesc: '在游戏内所有图标上显示舰船名称，而不仅仅是选中的目标。在视野中有200+飞行员时可能会影响性能。重启EVE客户端后生效。'
+  },
+  // 空状态
+  empty: {
+    noEveInstallations: '未找到EVE安装',
+    noEveInstallationsDesc: '请确保已安装EVE Online并至少启动过一次。'
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { createApp } from 'vue'
 import App from './App.vue'
 import './style.css'
+import i18n from './locales'
 
-createApp(App).mount('#app')
+createApp(App).use(i18n).mount('#app')


### PR DESCRIPTION
Adds multi-language support to EVE Wrench, currently supporting English and Chinese.

### New Features
- 🌐 Integrated Vue I18n internationalization framework
- 🔤 Support for English and Chinese language switching
- ⚙️ Added language selection option in the settings menu

### Technical Implementation
- Installed `vue-i18n@latest` dependency
- Created `src/locales/` directory structure:
  - `en.ts` - English language pack
  - `zh.ts` - Chinese language pack
  - `index.ts` - i18n configuration
- Created `useI18n` composable function for language switching
- Replaced hardcoded text in components

### Usage
1. Click the settings icon (gear) in the title bar
2. Find the "Language" section in the dropdown menu
3. Select English or 中文

### Adding New Languages
To add a new language:
1. Create a new language file in `src/locales/` (e.g., `ja.ts`)
2. Import and add it to `src/locales/index.ts`
3. Update the `supportedLocales` array

#### Note: Parts of this PR are written using Vibe Coding, and the code has undergone my full review.
---

